### PR TITLE
Fix originValue implementation

### DIFF
--- a/src/Sparkline.php
+++ b/src/Sparkline.php
@@ -110,7 +110,7 @@ class Sparkline
         list($width, $height) = $this->getNormalizedSize();
 
         $count = $this->getCount();
-        list($polygon, $line) = $this->getChartElements($this->data);
+        list($polygon, $line) = $this->getChartElements($this->getNormalizedData());
 
         $picture = new Picture($width, $height);
         $picture->applyBackground($this->backgroundColor);


### PR DESCRIPTION
`$this->getNormalizedData()` is using `$this->originValue` to calculate an offset but the resulting offsetted data are not used when drawing image. Without taking these normalized data, `$this->originValue` has no effect.