### PR TITLE
add paranthesis to ambigious line

### DIFF
--- a/src/Sparkline/PointTrait.php
+++ b/src/Sparkline/PointTrait.php
@@ -61,7 +61,7 @@ trait PointTrait
             throw new \InvalidArgumentException('Invalid index : ' . $index);
         }
         if ($index < 0 || $index >= $count) {
-            throw new \InvalidArgumentException('Index out of range [0-' . $count - 1 . '] : ' . $index);
+            throw new \InvalidArgumentException('Index out of range [0-' . ($count - 1) . '] : ' . $index);
         }
     }
 }


### PR DESCRIPTION
While testing with PHP 7.4(beta4), I came across the following deprecation warning:
> PHP message: PHP Deprecated:  The behavior of unparenthesized expressions containing both '.' and '+'/'-' will change in PHP 8: '+'/'-' will take a higher precedence in /var/www/matomo-beta/vendor/davaxi/sparkline/src/Sparkline/PointTrait.php on line 64

To be save, I think it is best to add paranthesis to make it clear.