### PR TITLE
Support displaying multiple series in a sparkline

### DIFF
--- a/src/Sparkline.php
+++ b/src/Sparkline.php
@@ -110,23 +110,26 @@ class Sparkline
         list($width, $height) = $this->getNormalizedSize();
 
         $count = $this->getCount();
-        list($polygon, $line) = $this->getChartElements($this->data);
 
         $picture = new Picture($width, $height);
         $picture->applyBackground($this->backgroundColor);
         $picture->applyThickness($this->lineThickness * $this->ratioComputing);
-        $picture->applyPolygon($polygon, $this->fillColor, $count);
-        $picture->applyLine($line, $this->lineColor);
 
-        foreach ($this->points as $point) {
-            $isFirst = $point['index'] === 0;
-            $lineIndex = $isFirst ? 0 : $point['index'] - 1;
-            $picture->applyDot(
-                $line[$lineIndex][$isFirst ? 0 : 2],
-                $line[$lineIndex][$isFirst ? 1 : 3],
-                $point['radius'] * $this->ratioComputing,
-                $point['color']
-            );
+        foreach ($this->data as $series) {
+            list($polygon, $line) = $this->getChartElements($series);
+            $picture->applyPolygon($polygon, $this->fillColor, $count);
+            $picture->applyLine($line, $this->lineColor);
+
+            foreach ($this->points as $point) {
+                $isFirst = $point['index'] === 0;
+                $lineIndex = $isFirst ? 0 : $point['index'] - 1;
+                $picture->applyDot(
+                    $line[$lineIndex][$isFirst ? 0 : 2],
+                    $line[$lineIndex][$isFirst ? 1 : 3],
+                    $point['radius'] * $this->ratioComputing,
+                    $point['color']
+                );
+            }
         }
 
         $this->file = $picture->generate($this->width, $this->height);

--- a/src/Sparkline.php
+++ b/src/Sparkline.php
@@ -115,8 +115,10 @@ class Sparkline
         $picture->applyBackground($this->backgroundColor);
         $picture->applyThickness($this->lineThickness * $this->ratioComputing);
 
+        $stepCount = $this->getMaxNumberOfDataPointsAcrossSerieses();
+
         foreach ($this->data as $seriesIndex => $series) {
-            list($polygon, $line) = $this->getChartElements($series);
+            list($polygon, $line) = $this->getChartElements($series, $stepCount);
             $picture->applyPolygon($polygon, $this->fillColor, $count);
 
             $lineColor = isset($this->lineColor[$seriesIndex]) ? $this->lineColor[$seriesIndex] : $this->lineColor[0];

--- a/src/Sparkline.php
+++ b/src/Sparkline.php
@@ -118,7 +118,9 @@ class Sparkline
         foreach ($this->data as $seriesIndex => $series) {
             list($polygon, $line) = $this->getChartElements($series);
             $picture->applyPolygon($polygon, $this->fillColor, $count);
-            $picture->applyLine($line, $this->lineColor[$seriesIndex]);
+
+            $lineColor = isset($this->lineColor[$seriesIndex]) ? $this->lineColor[$seriesIndex] : $this->lineColor[0];
+            $picture->applyLine($line, $lineColor);
 
             foreach ($this->points as $point) {
                 $isFirst = $point['index'] === 0;

--- a/src/Sparkline.php
+++ b/src/Sparkline.php
@@ -115,10 +115,10 @@ class Sparkline
         $picture->applyBackground($this->backgroundColor);
         $picture->applyThickness($this->lineThickness * $this->ratioComputing);
 
-        foreach ($this->data as $series) {
+        foreach ($this->data as $seriesIndex => $series) {
             list($polygon, $line) = $this->getChartElements($series);
             $picture->applyPolygon($polygon, $this->fillColor, $count);
-            $picture->applyLine($line, $this->lineColor);
+            $picture->applyLine($line, $this->lineColor[$seriesIndex]);
 
             foreach ($this->points as $point) {
                 $isFirst = $point['index'] === 0;

--- a/src/Sparkline.php
+++ b/src/Sparkline.php
@@ -123,6 +123,10 @@ class Sparkline
             $picture->applyLine($line, $lineColor);
 
             foreach ($this->points as $point) {
+                if ($point['series'] != $seriesIndex) {
+                    continue;
+                }
+
                 $isFirst = $point['index'] === 0;
                 $lineIndex = $isFirst ? 0 : $point['index'] - 1;
                 $picture->applyDot(

--- a/src/Sparkline/DataTrait.php
+++ b/src/Sparkline/DataTrait.php
@@ -155,6 +155,12 @@ trait DataTrait
         return max($maxes);
     }
 
+    protected function getMaxNumberOfDataPointsAcrossSerieses()
+    {
+        $counts = array_map('count', $this->data);
+        return max($counts);
+    }
+
     /**
      * @return array
      */

--- a/src/Sparkline/DataTrait.php
+++ b/src/Sparkline/DataTrait.php
@@ -50,26 +50,31 @@ trait DataTrait
     public function setData()
     {
         $allSeries = func_get_args();
-        if (empty($allSeries)) {
-            return;
-        }
 
         $this->data = [];
         foreach ($allSeries as $data) {
-            $data = array_values($data);
-            $count = count($data);
-            if (!$count) {
-                $this->data[] = [0, 0];
-
-                return;
-            }
-            if ($count < static::MIN_DATA_LENGTH) {
-                $this->data[] = array_fill(0, 2, $data[0]);
-
-                return;
-            }
-            $this->data[] = $data;
+            $this->addSeries($data);
         }
+    }
+
+    /**
+     * @param array $data
+     */
+    public function addSeries($data)
+    {
+        $data = array_values($data);
+        $count = count($data);
+        if (!$count) {
+            $this->data[] = [0, 0];
+
+            return;
+        }
+        if ($count < static::MIN_DATA_LENGTH) {
+            $this->data[] = array_fill(0, 2, $data[0]);
+
+            return;
+        }
+        $this->data[] = $data;
     }
 
     /**
@@ -137,6 +142,20 @@ trait DataTrait
     }
 
     /**
+     * TODO: this could be cached somehow
+     * @return float
+     */
+    protected function getMaxValueAcrossSeries()
+    {
+        if ($this->base) {
+            return $this->base;
+        }
+
+        $maxes = array_map('max', $this->data);
+        return max($maxes);
+    }
+
+    /**
      * @return array
      */
     protected function getMinValueWithIndex($seriesIndex = 0)
@@ -151,10 +170,10 @@ trait DataTrait
     /**
      * @return array
      */
-    protected function getExtremeValues()
+    protected function getExtremeValues($seriesIndex = 0)
     {
-        list($minIndex, $min) = $this->getMinValueWithIndex();
-        list($maxIndex, $max) = $this->getMaxValueWithIndex();
+        list($minIndex, $min) = $this->getMinValueWithIndex($seriesIndex);
+        list($maxIndex, $max) = $this->getMaxValueWithIndex($seriesIndex);
 
         return [$minIndex, $min, $maxIndex, $max];
     }

--- a/src/Sparkline/DataTrait.php
+++ b/src/Sparkline/DataTrait.php
@@ -22,7 +22,9 @@ trait DataTrait
     /**
      * @var array
      */
-    protected $data = [0, 0];
+    protected $data = [
+        [0, 0],
+    ];
 
     /**
      * @param $base
@@ -43,31 +45,47 @@ trait DataTrait
     }
 
     /**
-     * @param array $data
+     * @param array $data,...
      */
-    public function setData(array $data)
+    public function setData()
     {
-        $data = array_values($data);
-        $count = count($data);
-        if (!$count) {
-            $this->data = [0, 0];
-
+        $allSeries = func_get_args();
+        if (empty($allSeries)) {
             return;
         }
-        if ($count < static::MIN_DATA_LENGTH) {
-            $this->data = array_fill(0, 2, $data[0]);
 
-            return;
+        $this->data = [];
+        foreach ($allSeries as $data) {
+            $data = array_values($data);
+            $count = count($data);
+            if (!$count) {
+                $this->data[] = [0, 0];
+
+                return;
+            }
+            if ($count < static::MIN_DATA_LENGTH) {
+                $this->data[] = array_fill(0, 2, $data[0]);
+
+                return;
+            }
+            $this->data[] = $data;
         }
-        $this->data = $data;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSeriesCount()
+    {
+        return count($this->data);
     }
 
     /**
      * @return array
      */
-    public function getNormalizedData()
+    public function getNormalizedData($seriesIndex = 0)
     {
-        $data = $this->data;
+        $data = $this->data[$seriesIndex];
         foreach ($data as $i => $value) {
             $data[$i] = max(0, $value - $this->originValue);
         }
@@ -78,26 +96,26 @@ trait DataTrait
     /**
      * @return array
      */
-    public function getData()
+    public function getData($seriesIndex = 0)
     {
-        return $this->data;
+        return $this->data[$seriesIndex];
     }
 
     /**
      * @return int
      */
-    public function getCount()
+    public function getCount($seriesIndex = 0)
     {
-        return count($this->data);
+        return count($this->data[$seriesIndex]);
     }
 
     /**
      * @return array
      */
-    protected function getMaxValueWithIndex()
+    protected function getMaxValueWithIndex($seriesIndex = 0)
     {
-        $max = max($this->data);
-        $maxKeys = array_keys($this->data, $max);
+        $max = max($this->data[$seriesIndex]);
+        $maxKeys = array_keys($this->data[$seriesIndex], $max);
         $maxIndex = end($maxKeys);
         if ($this->base) {
             $max = $this->base;
@@ -109,22 +127,22 @@ trait DataTrait
     /**
      * @return float
      */
-    protected function getMaxValue()
+    protected function getMaxValue($seriesIndex = 0)
     {
         if ($this->base) {
             return $this->base;
         }
 
-        return max($this->data);
+        return max($this->data[$seriesIndex]);
     }
 
     /**
      * @return array
      */
-    protected function getMinValueWithIndex()
+    protected function getMinValueWithIndex($seriesIndex = 0)
     {
-        $min = min($this->data);
-        $minKey = array_keys($this->data, $min);
+        $min = min($this->data[$seriesIndex]);
+        $minKey = array_keys($this->data[$seriesIndex], $min);
         $minIndex = end($minKey);
 
         return [$minIndex, $min];

--- a/src/Sparkline/FormatTrait.php
+++ b/src/Sparkline/FormatTrait.php
@@ -200,12 +200,11 @@ trait FormatTrait
 
     /**
      * @param array $data
-     *
+     * @param int $count count of steps in sparkline image (does not have to == count($data))
      * @return array
      */
-    protected function getChartElements(array $data)
+    protected function getChartElements(array $data, $count)
     {
-        $count = count($data);
         $step = $this->getStepWidth($count);
         $height = $this->getInnerNormalizedHeight();
         $normalizedPadding = $this->getNormalizedPadding();
@@ -223,7 +222,7 @@ trait FormatTrait
         // First element
         $polygon[] = $pictureX1;
         $polygon[] = $pictureY1;
-        for ($i = 1; $i < $count; ++$i) {
+        for ($i = 1; $i < count($data); ++$i) {
             $pictureX2 = $pictureX1 + $step;
             $pictureY2 = $normalizedPadding['top'] + $height - $data[$i];
 

--- a/src/Sparkline/FormatTrait.php
+++ b/src/Sparkline/FormatTrait.php
@@ -181,7 +181,7 @@ trait FormatTrait
      */
     protected function getDataForChartElements(array $data, $height)
     {
-        $max = $this->getMaxValue();
+        $max = $this->getMaxValueAcrossSeries();
         $minHeight = 1 * $this->ratioComputing;
         $maxHeight = $height - $minHeight;
         foreach ($data as $i => $value) {

--- a/src/Sparkline/PointTrait.php
+++ b/src/Sparkline/PointTrait.php
@@ -17,17 +17,18 @@ trait PointTrait
      * @param $dotRadius
      * @param $colorHex
      */
-    public function addPoint($index, $dotRadius, $colorHex)
+    public function addPoint($index, $dotRadius, $colorHex, $seriesIndex = 0)
     {
-        $mapping = $this->getPointIndexMapping();
+        $mapping = $this->getPointIndexMapping($seriesIndex);
         if (array_key_exists($index, $mapping)) {
             $index = $mapping[$index];
             if ($index < 0) {
                 return;
             }
         }
-        $this->checkPointIndex($index);
+        $this->checkPointIndex($index, $seriesIndex);
         $this->points[] = [
+            'series' => $seriesIndex,
             'index' => $index,
             'radius' => $dotRadius,
             'color' => $this->colorHexToRGB($colorHex),
@@ -37,10 +38,10 @@ trait PointTrait
     /**
      * @return array
      */
-    protected function getPointIndexMapping()
+    protected function getPointIndexMapping($seriesIndex = 0)
     {
-        $count = $this->getCount();
-        list($minIndex, $min, $maxIndex, $max) = $this->getExtremeValues();
+        $count = $this->getCount($seriesIndex);
+        list($minIndex, $min, $maxIndex, $max) = $this->getExtremeValues($seriesIndex);
 
         $mapping = [];
         $mapping['first'] = $count > 1 ? 0 : -1;
@@ -54,9 +55,9 @@ trait PointTrait
     /**
      * @param $index
      */
-    protected function checkPointIndex($index)
+    protected function checkPointIndex($index, $seriesIndex)
     {
-        $count = $this->getCount();
+        $count = $this->getCount($seriesIndex);
         if (!is_numeric($index)) {
             throw new \InvalidArgumentException('Invalid index : ' . $index);
         }

--- a/src/Sparkline/StyleTrait.php
+++ b/src/Sparkline/StyleTrait.php
@@ -17,7 +17,9 @@ trait StyleTrait
      * @var array (rgb)
      *            Default: #1388db
      */
-    protected $lineColor = [19, 136, 219];
+    protected $lineColor = [
+        [19, 136, 219],
+    ];
 
     /**
      * @var array (rgb)
@@ -61,10 +63,10 @@ trait StyleTrait
     /**
      * @param string $color (hexadecimal)
      */
-    public function setLineColorHex($color)
+    public function setLineColorHex($color, $seriesIndex = 0)
     {
         list($red, $green, $blue) = $this->colorHexToRGB($color);
-        $this->setLineColorRGB($red, $green, $blue);
+        $this->setLineColorRGB($red, $green, $blue, $seriesIndex);
     }
 
     /**
@@ -72,9 +74,9 @@ trait StyleTrait
      * @param int $green
      * @param int $blue
      */
-    public function setLineColorRGB($red, $green, $blue)
+    public function setLineColorRGB($red, $green, $blue, $seriesIndex = 0)
     {
-        $this->lineColor = [$red, $green, $blue];
+        $this->lineColor[$seriesIndex] = [$red, $green, $blue];
     }
 
     /**


### PR DESCRIPTION
This change allows specifying multiple data series for display in a single sparkline:

![image](https://user-images.githubusercontent.com/125140/64549356-6aa43180-d2e5-11e9-8912-0b5749d652c6.png)

The change allows specifying line colors & point colors for each series (not fill colors since I didn't have a need for it) and is meant to be backwards compatible.

It allows each series to have a different number of data points, so one series can have 5 values, while another has 10 values. Such a sparkline would look like this:

![image](https://user-images.githubusercontent.com/125140/64549644-fa49e000-d2e5-11e9-9967-a512be02f0c4.png)

I haven't made any changes to the tests, I may be able to if I can find some time.