### PR TITLE
Enhance Travis CI and PHPUnit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ addons:
     code_climate:
         repo_token: 3b0878715671c2e346688330ab3b1f96c9f92b722d5bd9b4d2901fb39e6698b2
 
+dist: trusty
+
 php:
     - 5.4
     - 5.5
@@ -12,15 +14,15 @@ php:
     - 7.1
 
 before_install:
-    - curl -sS https://getcomposer.org/installer | php
+    - composer self-update
 
 install:
     - rm composer.json
     - mv composer.travis.json composer.json
-    - php composer.phar install --dev
+    - composer install
 
 script:
-    - phpunit --coverage-clover build/logs/clover.xml
+    - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
     - vendor/bin/test-reporter

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "ext-gd": "*"
     },
     "require-dev": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "codeclimate/php-test-reporter": "dev-master",
         "ext-gd": "*",
         "phpro/grumphp": "^0.12.0",
@@ -37,7 +37,8 @@
         "sebastian/phpcpd": "^3.0",
         "squizlabs/php_codesniffer": "^3.1",
         "friendsofphp/php-cs-fixer": "^2.8",
-        "wearejust/grumphp-extra-tasks": "^2.1"
+        "wearejust/grumphp-extra-tasks": "^2.1",
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-4": {

--- a/composer.travis.json
+++ b/composer.travis.json
@@ -29,7 +29,8 @@
     "require-dev": {
         "php": ">=5.3.0",
         "codeclimate/php-test-reporter": "dev-master",
-        "ext-gd": "*"
+        "ext-gd": "*",
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-4": {

--- a/tests/SparklineTest.php
+++ b/tests/SparklineTest.php
@@ -20,13 +20,13 @@ class SparklineTest extends SparklinePHPUnit
      */
     protected $sparkline;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->sparkline = new SparklineMockup();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         $this->sparkline->destroy();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,13 +4,8 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 date_default_timezone_set('Europe/Paris');
 
-if (class_exists('PHPUnit_Framework_TestCase')) {
-    class SparklinePHPUnit extends PHPUnit_Framework_TestCase
-    {
-    }
-}
-else {
-    class SparklinePHPUnit extends \PHPUnit\Framework\TestCase
-    {
-    }
+use PHPUnit\Framework\TestCase;
+
+class SparklinePHPUnit extends TestCase
+{
 }


### PR DESCRIPTION
# Changed log
- The Travis CI has the `composer` execution. And it's unnecessary to download `composer` via `curl`.
- It seems that the `php-5.3` cannot support this package. Using the minimal `php-5.4` version instead.
- Defining the `PHPUnit` version on `composer.json` and `composer.travis.json` and it can help developers/users to execute unit tests easily.
- The PHPUnit fixtures are `protected` `setUp` and `tearDown` methods.
- Using the `PHPUnit` class namespace to support latest stable `PHPUnit` version.