### PR TITLE
Ensure StyleTrait::getFillColor() returns correct type

### DIFF
--- a/src/Sparkline/StyleTrait.php
+++ b/src/Sparkline/StyleTrait.php
@@ -135,6 +135,10 @@ trait StyleTrait
      */
     public function getFillColor($seriesIndex = 0)
     {
+        if (empty($this->fillColor)) {
+            return [];
+        }
+
         return isset($this->fillColor[$seriesIndex]) ? $this->fillColor[$seriesIndex] : $this->fillColor[0];
     }
 


### PR DESCRIPTION
When `StyleTrait::deactivateFillColor()` is called `$this->fillColor` is set to an empty array. Calling `getFillColor` with any seriesIndex will then return `null`. 

That will cause a failure for example here: https://github.com/davaxi/Sparkline/blob/c3bc056a0dd6f8b29a5b3bdf8c9daee1e206fbc3/src/Sparkline.php#L122
as `applyPolygon` requires the second parameter to be an array

fixes #14