### PR TITLE
Fixes deprecation warning on PHP 8.1

### DIFF
--- a/src/Sparkline/Picture.php
+++ b/src/Sparkline/Picture.php
@@ -109,7 +109,11 @@ class Picture
             return;
         }
         $fillColor = imagecolorallocate($this->resource, $fillColor[0], $fillColor[1], $fillColor[2]);
-        imagefilledpolygon($this->resource, $polygon, $count + 2, $fillColor);
+        if (version_compare(PHP_VERSION, '8.1.0') === -1) {
+            imagefilledpolygon($this->resource, $polygon, $count + 2, $fillColor);
+        } else {
+            imagefilledpolygon($this->resource, $polygon, $fillColor);
+        }
     }
 
     /**


### PR DESCRIPTION
```
vendor/davaxi/sparkline/src/Sparkline/Picture.php(112): Deprecated - imagefilledpolygon(): Using the $num_points parameter is deprecated
```