### PR TITLE
Allow deactivating fill color for a specific series

### DIFF
--- a/src/Sparkline/StyleTrait.php
+++ b/src/Sparkline/StyleTrait.php
@@ -107,6 +107,7 @@ trait StyleTrait
 
     /**
      * Set fill color to transparent.
+	 * @param int|null $seriesIndex
      */
     public function deactivateFillColor(?int $seriesIndex = null)
     {

--- a/src/Sparkline/StyleTrait.php
+++ b/src/Sparkline/StyleTrait.php
@@ -108,9 +108,13 @@ trait StyleTrait
     /**
      * Set fill color to transparent.
      */
-    public function deactivateFillColor()
+    public function deactivateFillColor(?int $seriesIndex = null)
     {
-        $this->fillColor = [];
+        if ($seriesIndex === null) {
+            $this->fillColor = [];
+        } else {
+            unset($this->fillColor[$seriesIndex]);
+        }
     }
 
     /**
@@ -140,11 +144,11 @@ trait StyleTrait
      */
     public function getFillColor(int $seriesIndex = 0): array
     {
-        if (empty($this->fillColor)) {
+        if (empty($this->fillColor) || !isset($this->fillColor[$seriesIndex])) {
             return [];
         }
 
-        return $this->fillColor[$seriesIndex] ?? $this->fillColor[0];
+        return $this->fillColor[$seriesIndex];
     }
 
     /**


### PR DESCRIPTION
I'm wanting to use davaxi/sparkline for multiple series, but where the primary series has a fill color, but the secondary series does not. Currently the `deactivateFillColor()` method clears all fill colors, so I've added an optional (for backwards compatibility) `$seriesIndex` argument that allows a user to specify a series to clear. This also changes `getFillColor()` to not fall back to the first series fill color, if secondary series do not have their own fill color.