### PR TITLE
Ensure chart elements don't exceed maximum available width

### DIFF
--- a/src/Sparkline/FormatTrait.php
+++ b/src/Sparkline/FormatTrait.php
@@ -209,6 +209,7 @@ trait FormatTrait
     {
         $step = $this->getStepWidth($count);
         $height = $this->getInnerNormalizedHeight();
+        $width = $this->getInnerNormalizedWidth();
         $normalizedPadding = $this->getNormalizedPadding();
         $data = $this->getDataForChartElements($data, $height);
 
@@ -225,8 +226,8 @@ trait FormatTrait
         $polygon[] = $pictureX1;
         $polygon[] = $pictureY1;
         for ($i = 1; $i < count($data); ++$i) {
-            $pictureX2 = (int)ceil($pictureX1 + $step);
-            $pictureY2 = (int)ceil($normalizedPadding['top'] + $height - $data[$i]);
+            $pictureX2 = min((int)ceil($pictureX1 + $step), $normalizedPadding['right'] + $width);
+            $pictureY2 = min((int)ceil($normalizedPadding['top'] + $height - $data[$i]), $normalizedPadding['top'] + $height);
 
             $line[] = [$pictureX1, $pictureY1, $pictureX2, $pictureY2];
 


### PR DESCRIPTION
I'm not sure if this fix is the optimal solution. But since #20 we have a small regression in our generated sparklines.
For reference see https://github.com/matomo-org/matomo/issues/18863

It seems the `ceil` that was added now causes that the chart elements that are generated exceed the maximum width.
The provided fix should ensure, that the last element doesn't exceed the available width.

For our case this seems to fix the problem.